### PR TITLE
Reading empty lines from /proc/stat causes panic

### DIFF
--- a/sigar_linux.go
+++ b/sigar_linux.go
@@ -25,7 +25,7 @@ func init() {
 
 	// grab system boot time
 	readFile(procd+"stat", func(line string) bool {
-		if line[0:5] == "btime" {
+		if strings.HasPrefix(line, "btime") {
 			system.btime, _ = strtoull(line[6:])
 			return false // stop reading
 		}


### PR DESCRIPTION
When reading `/proc/stat` empty lines would cause a panic. Fixed by using `strings.HasPrefix` instead.
