### PR TITLE
Fix a compilation error on linux x86

### DIFF
--- a/sigar_linux.go
+++ b/sigar_linux.go
@@ -88,8 +88,8 @@ func (self *Swap) Get() error {
 		return err
 	}
 
-	self.Total = sysinfo.Totalswap
-	self.Free = sysinfo.Freeswap
+	self.Total = uint64(sysinfo.Totalswap)
+	self.Free = uint64(sysinfo.Freeswap)
 	self.Used = self.Total - self.Free
 
 	return nil


### PR DESCRIPTION
It appears that TotalSwap and FreeSwap are uint32 on 32 bit architectures which is causing the compilation to fail since we're assigning uint32 to uint64.
