### PR TITLE
Fix so this builds on 32 bit linux systems, modified linux swap information call

### DIFF
--- a/sigar_linux.go
+++ b/sigar_linux.go
@@ -90,8 +90,8 @@ func (self *Swap) Get() error {
 		return err
 	}
 
-	self.Total = sysinfo.Totalswap
-	self.Free = sysinfo.Freeswap
+	self.Total = uint64(sysinfo.Totalswap)
+	self.Free = uint64(sysinfo.Freeswap)
 	self.Used = self.Total - self.Free
 
 	return nil


### PR DESCRIPTION
I ran into an issue when targeting ARM, which in my case is a 32 bit platform as the system calls this library invokes return the native int. 

I see this has been raised before in #5, this patch ensures the values are always cast to 64 bit.
