### PR TITLE
Fix some kind of cast error on linux host

### DIFF
--- a/sigar_linux.go
+++ b/sigar_linux.go
@@ -90,8 +90,8 @@ func (self *Swap) Get() error {
 		return err
 	}
 
-	self.Total = sysinfo.Totalswap
-	self.Free = sysinfo.Freeswap
+	self.Total = uint64(sysinfo.Totalswap)
+	self.Free = uint64(sysinfo.Freeswap)
 	self.Used = self.Total - self.Free
 
 	return nil


### PR DESCRIPTION
Hi !
This just happens when I started a `go get` :

```
# github.com/cloudfoundry/gosigar
../../cloudfoundry/gosigar/sigar_linux.go:93: cannot use sysinfo.Totalswap (type uint32) as type uint64 in assignment
../../cloudfoundry/gosigar/sigar_linux.go:94: cannot use sysinfo.Freeswap (type uint32) as type uint64 in assignment
```

I'm absolutely not a Go-guru, but do you think this change is valid ?
It successfully fixed my 32/64 casting issue !

Thx :)
