### PR TITLE
Skip /proc/stat lines which are too short

### DIFF
--- a/sigar_linux.go
+++ b/sigar_linux.go
@@ -99,7 +99,7 @@ func (self *Swap) Get() error {
 
 func (self *Cpu) Get() error {
 	return readFile(Procd+"/stat", func(line string) bool {
-		if line[0:4] == "cpu " {
+		if len(line) > 4 && line[0:4] == "cpu " {
 			parseCpuStat(self, line)
 			return false
 		}
@@ -116,7 +116,7 @@ func (self *CpuList) Get() error {
 	list := make([]Cpu, 0, capacity)
 
 	err := readFile(Procd+"/stat", func(line string) bool {
-		if line[0:3] == "cpu" && line[3] != ' ' {
+		if len(line) > 3 && line[0:3] == "cpu" && line[3] != ' ' {
 			cpu := Cpu{}
 			parseCpuStat(&cpu, line)
 			list = append(list, cpu)


### PR DESCRIPTION
Hi,

On some system (like VMs under OpenVZ), `/proc/stat` file contains empty lines leading to a panic:

```
panic: runtime error: slice bounds out of range

goroutine 20 [running]:
runtime.panic(0x6ba5c0, 0x88624f)
        /usr/local/go/src/pkg/runtime/panic.c:279 +0xf5
github.com/cloudfoundry/gosigar.func·004(0x0, 0x0, 0xf96)
        /gopath/src/github.com/cloudfoundry/gosigar/sigar_linux.go:119 +0x1b7
github.com/cloudfoundry/gosigar.readFile(0xc208000380, 0xa, 0x7fe585f8ed50, 0x0, 0x0)
        /gopath/src/github.com/cloudfoundry/gosigar/sigar_linux.go:357 +0x245
github.com/cloudfoundry/gosigar.(*CpuList).Get(0x7fe585f8eec8, 0x0, 0x0)
        /gopath/src/github.com/cloudfoundry/gosigar/sigar_linux.go:125 +0xe9
main.cpus(0xc20800e580, 0x16, 0xc208004240, 0x0, 0x0)
        /gopath/src/github.com/novaquark/sysinfo_influxdb/main.go:359 +0x1b0
created by main.main
        /gopath/src/github.com/novaquark/sysinfo_influxdb/main.go:187 +0xa02
```

On that (virtual) machine, the `/proc/stat` file looks like:

```
# cat -e /proc/stat
cpu  2181567 0 410886 150502608 123947 0 0 0$
cpu0 2181567 0 410886 150502608 123947 0 0 0$
intr 0$
swap 0 0$
$
ctxt 264417282$
btime 1418942026$
processes 215136$
procs_running 1$
procs_blocked 0$
```

This PR adds line length tests before slicing it.