### PR TITLE
Add SystemInfo

### DIFF
--- a/concrete_sigar.go
+++ b/concrete_sigar.go
@@ -67,3 +67,9 @@ func (c *ConcreteSigar) GetFileSystemUsage(path string) (FileSystemUsage, error)
 	err := f.Get(path)
 	return f, err
 }
+
+func (c *ConcreteSigar) GetSystemInfo() (SystemInfo, error) {
+	s := SystemInfo{}
+	err := s.Get()
+	return s, err
+}

--- a/examples/system_info.go
+++ b/examples/system_info.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"fmt"
+	"github.com/abimaelmartell/gosigar"
+)
+
+func main() {
+	concreteSigar := sigar.ConcreteSigar{}
+	systemInfo, _ := concreteSigar.GetSystemInfo()
+
+	fmt.Println("Name:", systemInfo.Name)
+	fmt.Println("Version:", systemInfo.Version)
+	fmt.Println("Arch:", systemInfo.Arch)
+	fmt.Println("Machine:", systemInfo.Machine)
+	fmt.Println("Description:", systemInfo.Description)
+	fmt.Println("PatchLevel:", systemInfo.PatchLevel)
+	fmt.Println("Vendor:", systemInfo.Vendor)
+	fmt.Println("VendorVersion:", systemInfo.VendorVersion)
+	fmt.Println("VendorName:", systemInfo.VendorName)
+	fmt.Println("VendorCodeName:", systemInfo.VendorCodeName)
+}

--- a/examples/system_info.go
+++ b/examples/system_info.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/abimaelmartell/gosigar"
+	"github.com/cloudfoundry/gosigar"
 )
 
 func main() {

--- a/sigar_darwin.go
+++ b/sigar_darwin.go
@@ -5,7 +5,6 @@ package sigar
 /*
 #cgo LDFLAGS: -framework CoreServices
 #include <stdlib.h>
-#include <sys/utsname.h>
 #include <sys/sysctl.h>
 #include <sys/mount.h>
 #include <mach/mach_init.h>
@@ -320,6 +319,8 @@ func (self *ProcExe) Get(pid int) error {
 }
 
 func (self *SystemInfo) Get() error {
+	self.getFromUname()
+
 	self.Name = "MacOSX"
 	self.VendorName = "Mac OS X"
 	self.Vendor = "Apple"
@@ -359,14 +360,6 @@ func (self *SystemInfo) Get() error {
 	}
 
 	self.VendorCodeName = codeName
-
-	// Arch
-	var unameBuf C.struct_utsname
-	C.uname(&unameBuf)
-
-	self.Arch = C.GoString(&unameBuf.machine[0])
-	self.Machine = self.Arch
-	self.PatchLevel = "unknown"
 	self.Description = fmt.Sprintf("%s %s", self.VendorName, self.VendorCodeName)
 
 	return nil

--- a/sigar_darwin.go
+++ b/sigar_darwin.go
@@ -3,7 +3,9 @@
 package sigar
 
 /*
+#cgo LDFLAGS: -framework CoreServices
 #include <stdlib.h>
+#include <sys/utsname.h>
 #include <sys/sysctl.h>
 #include <sys/mount.h>
 #include <mach/mach_init.h>
@@ -12,6 +14,7 @@ package sigar
 #include <libproc.h>
 #include <mach/processor_info.h>
 #include <mach/vm_map.h>
+#include <CoreServices/CoreServices.h>
 */
 import "C"
 
@@ -314,6 +317,59 @@ func (self *ProcExe) Get(pid int) error {
 	}
 
 	return kern_procargs(pid, exe, nil, nil)
+}
+
+func (self *SystemInfo) Get() error {
+	self.Name = "MacOSX"
+	self.VendorName = "Mac OS X"
+	self.Vendor = "Apple"
+
+	var majorVersion, minorVersion, bugFixVersion C.SInt32
+
+	C.Gestalt(C.gestaltSystemVersionMajor, &majorVersion)
+	C.Gestalt(C.gestaltSystemVersionMinor, &minorVersion)
+	C.Gestalt(C.gestaltSystemVersionBugFix, &bugFixVersion)
+
+	self.VendorVersion = fmt.Sprintf("%d.%d", majorVersion, minorVersion)
+	self.Version = fmt.Sprintf("%d.%d.%d", majorVersion, minorVersion, bugFixVersion)
+
+	var codeName string
+
+	switch majorVersion {
+	case 2:
+		codeName = "Jaguar"
+	case 3:
+		codeName = "Panther"
+	case 4:
+		codeName = "Tiger"
+	case 5:
+		codeName = "Leopard"
+	case 6:
+		codeName = "Snow Leopard"
+	case 7:
+		codeName = "Lion"
+	case 8:
+		codeName = "Mountain Lion"
+	case 9:
+		codeName = "Mavericks"
+	case 10:
+		codeName = "Yosemite"
+	default:
+		// :O
+	}
+
+	self.VendorCodeName = codeName
+
+	// Arch
+	var unameBuf C.struct_utsname
+	C.uname(&unameBuf)
+
+	self.Arch = C.GoString(&unameBuf.machine[0])
+	self.Machine = self.Arch
+	self.PatchLevel = "unknown"
+	self.Description = fmt.Sprintf("%s %s", self.VendorName, self.VendorCodeName)
+
+	return nil
 }
 
 // wrapper around sysctl KERN_PROCARGS2

--- a/sigar_interface.go
+++ b/sigar_interface.go
@@ -10,6 +10,7 @@ type Sigar interface {
 	GetMem() (Mem, error)
 	GetSwap() (Swap, error)
 	GetFileSystemUsage(string) (FileSystemUsage, error)
+	GetSystemInfo() (SystemInfo, error)
 }
 
 type Cpu struct {
@@ -138,4 +139,17 @@ type ProcExe struct {
 	Name string
 	Cwd  string
 	Root string
+}
+
+type SystemInfo struct {
+	Name           string
+	Version        string
+	Arch           string
+	Machine        string
+	Description    string
+	PatchLevel     string
+	Vendor         string
+	VendorVersion  string
+	VendorName     string
+	VendorCodeName string
 }

--- a/sigar_linux.go
+++ b/sigar_linux.go
@@ -370,6 +370,8 @@ func (self *SystemInfo) Get() error {
 
 		if err != nil {
 			panic(err)
+
+			return nil
 		}
 
 		if linuxVendor.Parser != nil {

--- a/sigar_linux.go
+++ b/sigar_linux.go
@@ -5,9 +5,11 @@ package sigar
 import (
 	"bufio"
 	"bytes"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"syscall"
@@ -305,6 +307,76 @@ func (self *ProcExe) Get(pid int) error {
 		}
 
 		*field = val
+	}
+
+	return nil
+}
+
+type LinuxVendor struct {
+	Name   string
+	File   string
+	Parser func(*SystemInfo, []byte) error
+}
+
+type LinuxVendors []LinuxVendor
+
+func lsbVendorParser(systemInfo *SystemInfo, releaseFileContent []byte) error {
+	regex, _ := regexp.Compile(`(\w+)="?([\w.\ ]+)"?`)
+
+	matches := regex.FindAllStringSubmatch(string(releaseFileContent), -1)
+
+	for _, v := range matches {
+		if v[1] == "DISTRIB_ID" {
+			systemInfo.Vendor = v[2]
+		}
+
+		if v[1] == "DISTRIB_RELEASE" {
+			systemInfo.VendorVersion = v[2]
+		}
+
+		if v[1] == "DISTRIB_CODENAME" {
+			systemInfo.VendorCodeName = v[2]
+		}
+	}
+
+	return nil
+}
+
+var linuxVendors = LinuxVendors{
+	{
+		Name:   "LBS",
+		File:   "/etc/lsb-release",
+		Parser: lsbVendorParser,
+	},
+}
+
+func (self *SystemInfo) Get() error {
+	self.getFromUname()
+
+	var linuxVendor LinuxVendor
+
+	for i := range linuxVendors {
+		_, err := os.Stat(linuxVendors[i].File)
+
+		if err == nil {
+			linuxVendor = linuxVendors[i]
+
+			break
+		}
+	}
+
+	if linuxVendor.File != "" {
+		releaseFileContent, err := ioutil.ReadFile(linuxVendor.File)
+
+		if err != nil {
+			panic(err)
+		}
+
+		if linuxVendor.Parser != nil {
+			linuxVendor.Parser(self, releaseFileContent)
+		}
+
+		self.Description = fmt.Sprintf("%s %s", self.Vendor, self.VendorVersion)
 	}
 
 	return nil

--- a/sigar_unix.go
+++ b/sigar_unix.go
@@ -4,6 +4,10 @@
 
 package sigar
 
+/*
+#include <sys/utsname.h>
+*/
+import "C"
 import "syscall"
 
 func (self *FileSystemUsage) Get(path string) error {
@@ -23,4 +27,16 @@ func (self *FileSystemUsage) Get(path string) error {
 	self.FreeFiles = stat.Ffree
 
 	return nil
+}
+
+func (self *SystemInfo) getFromUname() {
+	var unameBuf C.struct_utsname
+	C.uname(&unameBuf)
+
+	self.Version = C.GoString(&unameBuf.release[0])
+	self.VendorName = C.GoString(&unameBuf.sysname[0])
+	self.Name = C.GoString(&unameBuf.sysname[0])
+	self.Machine = C.GoString(&unameBuf.machine[0])
+	self.Arch = C.GoString(&unameBuf.machine[0])
+	self.PatchLevel = "unknown"
 }

--- a/sigar_windows.go
+++ b/sigar_windows.go
@@ -94,6 +94,10 @@ func (self *FileSystemUsage) Get(path string) error {
 	return nil
 }
 
+func (self *SystemInfo) Get() error {
+	return notImplemented()
+}
+
 func notImplemented() error {
 	panic("Not Implemented")
 	return nil


### PR DESCRIPTION
Added SystemInfo struct following the same structure as [hyperic/sigar](https://github.com/hyperic/sigar)

https://github.com/hyperic/sigar/blob/master/include/sigar.h#L952

Implemented for Darwin and Linux, currently only supports LSB distros, but i will work on support more distributions and maybe windows later.

As you may notice, most of the code is a go port of [hyperic/sigar](https://github.com/hyperic/sigar)'s code.

Let me know if there are any problems with my code.
