### PR TITLE
Set 'ActualFree' memory on windows to be the same as Free memory

### DIFF
--- a/sigar_windows.go
+++ b/sigar_windows.go
@@ -60,6 +60,7 @@ func (m *Mem) Get() error {
 	}
 	m.Total = x.TotalPhys
 	m.Free = x.AvailPhys
+	m.ActualFree = m.Free
 	m.Used = m.Total - m.Free
 	return nil
 }

--- a/sigar_windows_test.go
+++ b/sigar_windows_test.go
@@ -25,6 +25,7 @@ var _ = Describe("SigarWindows", func() {
 			Expect(mem.Get()).To(Succeed())
 			Expect(mem.Total).To(BeNumerically(">", 0))
 			Expect(mem.Free).To(BeNumerically(">", 0))
+			Expect(mem.ActualFree).To(BeNumerically(">", 0))
 			Expect(mem.Used).To(BeNumerically(">", 0))
 		})
 	})


### PR DESCRIPTION
Signed-off-by: Mark DeLillo <mdelillo@pivotal.io>