### PR TITLE
On Windows return ErrNotSupported when DLL Procs cannot be loaded

### DIFF
--- a/sigar_interface.go
+++ b/sigar_interface.go
@@ -6,6 +6,7 @@ import (
 )
 
 var ErrNotImplemented = errors.New("gosigar: not implemented")
+var ErrNotSupported = errors.New("gosigar: not supported")
 
 type Sigar interface {
 	CollectCpuStats(collectionInterval time.Duration) (<-chan Cpu, chan<- struct{})

--- a/sigar_windows.go
+++ b/sigar_windows.go
@@ -14,19 +14,32 @@ import (
 )
 
 var (
-	kernel32DLL = syscall.MustLoadDLL("kernel32")
-
-	procGetDiskFreeSpace     = kernel32DLL.MustFindProc("GetDiskFreeSpaceW")
-	procGetSystemTimes       = kernel32DLL.MustFindProc("GetSystemTimes")
-	procGetTickCount64       = kernel32DLL.MustFindProc("GetTickCount64")
-	procGlobalMemoryStatusEx = kernel32DLL.MustFindProc("GlobalMemoryStatusEx")
+	kernel32DLL              *syscall.DLL
+	procGetDiskFreeSpace     *syscall.Proc
+	procGetSystemTimes       *syscall.Proc
+	procGlobalMemoryStatusEx *syscall.Proc
+	procGetTickCount64       *syscall.Proc
 )
+
+func init() {
+	kernel32DLL, _ = syscall.LoadDLL("kernel32")
+	if kernel32DLL == nil {
+		return
+	}
+	procGetDiskFreeSpace, _ = kernel32DLL.FindProc("GetDiskFreeSpaceW")
+	procGetSystemTimes, _ = kernel32DLL.FindProc("GetSystemTimes")
+	procGlobalMemoryStatusEx, _ = kernel32DLL.FindProc("GlobalMemoryStatusEx")
+	procGetTickCount64, _ = kernel32DLL.FindProc("GetTickCount64")
+}
 
 func (self *LoadAverage) Get() error {
 	return ErrNotImplemented
 }
 
 func (u *Uptime) Get() error {
+	if procGetTickCount64 == nil {
+		return ErrNotSupported
+	}
 	r1, _, e1 := syscall.Syscall(procGetTickCount64.Addr(), 0, 0, 0, 0)
 	if e1 != 0 {
 		return error(e1)
@@ -48,6 +61,10 @@ type memorystatusex struct {
 }
 
 func (m *Mem) Get() error {
+	if procGlobalMemoryStatusEx == nil {
+		return ErrNotSupported
+	}
+
 	var x memorystatusex
 	x.Length = uint32(unsafe.Sizeof(x))
 	r1, _, e1 := syscall.Syscall(procGlobalMemoryStatusEx.Addr(), 1,
@@ -98,6 +115,9 @@ func parseWmicOutput(s, sep []byte) (uint64, error) {
 }
 
 func (c *Cpu) Get() error {
+	if procGetSystemTimes == nil {
+		return ErrNotSupported
+	}
 	var (
 		idleTime   syscall.Filetime
 		kernelTime syscall.Filetime // Includes kernel and idle time.
@@ -151,6 +171,9 @@ func (self *ProcExe) Get(pid int) error {
 }
 
 func (fs *FileSystemUsage) Get(path string) error {
+	if procGetDiskFreeSpace == nil {
+		return ErrNotSupported
+	}
 	root, err := syscall.UTF16PtrFromString(path)
 	if err != nil {
 		return fmt.Errorf("FileSystemUsage (%s): %s", path, err)


### PR DESCRIPTION
Adds support for older versions of Windows.  Previously, `gosigar` would panic if kernel32 or any procs could not be loaded.