### PR TITLE
windows should return disk stats in KB not bytes

### DIFF
--- a/sigar_windows.go
+++ b/sigar_windows.go
@@ -181,7 +181,7 @@ func (fs *FileSystemUsage) Get(path string) error {
 		return fmt.Errorf("FileSystemUsage (%s): %s", path, err)
 	}
 
-	m := uint64(SectorsPerCluster * BytesPerSector)
+	m := uint64(SectorsPerCluster * BytesPerSector / 1024)
 	fs.Total = uint64(TotalNumberOfClusters) * m
 	fs.Free = uint64(NumberOfFreeClusters) * m
 	fs.Avail = fs.Free


### PR DESCRIPTION
Matches linux behavior