### PR TITLE
Support for MemAvailable if /proc/meminfo returns it.

### DIFF
--- a/sigar_linux.go
+++ b/sigar_linux.go
@@ -13,6 +13,8 @@ import (
 	"syscall"
 )
 
+const MaxUint64 = ^uint64(0)
+
 var system struct {
 	ticks uint64
 	btime uint64
@@ -63,22 +65,28 @@ func (self *Uptime) Get() error {
 }
 
 func (self *Mem) Get() error {
+	var available uint64 = MaxUint64
 	var buffers, cached uint64
 	table := map[string]*uint64{
-		"MemTotal": &self.Total,
-		"MemFree":  &self.Free,
-		"Buffers":  &buffers,
-		"Cached":   &cached,
+		"MemTotal":     &self.Total,
+		"MemFree":      &self.Free,
+		"MemAvailable": &available,
+		"Buffers":      &buffers,
+		"Cached":       &cached,
 	}
 
 	if err := parseMeminfo(table); err != nil {
 		return err
 	}
 
+	if available == MaxUint64 {
+		self.ActualFree = self.Free + buffers + cached
+	} else {
+		self.ActualFree = available
+	}
+
 	self.Used = self.Total - self.Free
-	kern := buffers + cached
-	self.ActualFree = self.Free + kern
-	self.ActualUsed = self.Used - kern
+	self.ActualUsed = self.Total - self.ActualFree
 
 	return nil
 }

--- a/sigar_linux_test.go
+++ b/sigar_linux_test.go
@@ -95,7 +95,7 @@ var _ = Describe("sigarLinux", func() {
 		})
 	})
 
-	Describe("Mem", func() {
+	Describe("Mem without MemAvailable", func() {
 		var meminfoFile string
 		BeforeEach(func() {
 			meminfoFile = procd + "/meminfo"
@@ -155,6 +155,76 @@ DirectMap2M:      333824 kB
 
 			Expect(mem.Total).To(BeNumerically("==", 374256*1024))
 			Expect(mem.Free).To(BeNumerically("==", 274460*1024))
+			Expect(mem.ActualFree).To(BeNumerically("==", 322872*1024))
+			Expect(mem.ActualUsed).To(BeNumerically("==", 51384*1024))
+		})
+	})
+
+	Describe("Mem with MemAvailable", func() {
+		var meminfoFile string
+		BeforeEach(func() {
+			meminfoFile = procd + "/meminfo"
+
+			meminfoContents := `
+MemTotal:       35008180 kB
+MemFree:          487816 kB
+MemAvailable:   20913400 kB
+Buffers:          249244 kB
+Cached:          5064684 kB
+SwapCached:       158628 kB
+Active:         10974348 kB
+Inactive:        7441132 kB
+Active(anon):    7921056 kB
+Inactive(anon):  5192512 kB
+Active(file):    3053292 kB
+Inactive(file):  2248620 kB
+Unevictable:           4 kB
+Mlocked:               4 kB
+SwapTotal:      35013660 kB
+SwapFree:       33981728 kB
+Dirty:               652 kB
+Writeback:             0 kB
+AnonPages:      12975584 kB
+Mapped:           341188 kB
+Shmem:             12280 kB
+Slab:           15754916 kB
+SReclaimable:   15534604 kB
+SUnreclaim:       220312 kB
+KernelStack:       42960 kB
+PageTables:        52744 kB
+NFS_Unstable:          0 kB
+Bounce:                0 kB
+WritebackTmp:          0 kB
+CommitLimit:    52517748 kB
+Committed_AS:   22939984 kB
+VmallocTotal:   34359738367 kB
+VmallocUsed:           0 kB
+VmallocChunk:          0 kB
+HardwareCorrupted:     0 kB
+AnonHugePages:  11448320 kB
+CmaTotal:              0 kB
+CmaFree:               0 kB
+HugePages_Total:       0
+HugePages_Free:        0
+HugePages_Rsvd:        0
+HugePages_Surp:        0
+Hugepagesize:       2048 kB
+DirectMap4k:      667520 kB
+DirectMap2M:    34983936 kB
+`
+			err := ioutil.WriteFile(meminfoFile, []byte(meminfoContents), 0444)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("returns correct memory info", func() {
+			mem := Mem{}
+			err := mem.Get()
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(mem.Total).To(BeNumerically("==", 35008180*1024))
+			Expect(mem.Free).To(BeNumerically("==", 487816*1024))
+			Expect(mem.ActualFree).To(BeNumerically("==", 20913400*1024))
+			Expect(mem.ActualUsed).To(BeNumerically("==", 14094780*1024))
 		})
 	})
 


### PR DESCRIPTION
This is a PR for issue: https://github.com/cloudfoundry/gosigar/issues/38

Calculates ActualFree and ActualUsed using MemAvailable if /proc/meminfo returns it (Kernal 3.14+).  Otherwise no changes to the current memory calculation method was made even though, according to the commit that added MemAvailable, the current calculation may be flawed: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=34e431b0a

Added a test for MemAvailable and improved some of the assertions in the old test.