### PR TITLE
psnotify: add exit code to ProcEventExit

### DIFF
--- a/psnotify/psnotify.go
+++ b/psnotify/psnotify.go
@@ -17,7 +17,8 @@ type ProcEventExec struct {
 }
 
 type ProcEventExit struct {
-	Pid int // Pid of the process that called exit()
+	Pid  int // Pid of the process that called exit()
+	Exit int // Exit code of the process.
 }
 
 type watch struct {

--- a/psnotify/psnotify_bsd.go
+++ b/psnotify/psnotify_bsd.go
@@ -80,8 +80,9 @@ func (w *Watcher) readEvents() {
 			case syscall.NOTE_EXEC:
 				w.Exec <- &ProcEventExec{Pid: pid}
 			case syscall.NOTE_EXIT:
+				exit := int(ev.Data)
 				w.RemoveWatch(pid)
-				w.Exit <- &ProcEventExit{Pid: pid}
+				w.Exit <- &ProcEventExit{Pid: pid, Exit: exit}
 			}
 		}
 	}

--- a/psnotify/psnotify_linux.go
+++ b/psnotify/psnotify_linux.go
@@ -185,10 +185,11 @@ func (w *Watcher) handleEvent(data []byte) {
 		event := &exitProcEvent{}
 		binary.Read(buf, byteOrder, event)
 		pid := int(event.ProcessTgid)
+		exit := int(event.ExitCode)
 
 		if w.isWatching(pid, PROC_EVENT_EXIT) {
 			w.RemoveWatch(pid)
-			w.Exit <- &ProcEventExit{Pid: pid}
+			w.Exit <- &ProcEventExit{Pid: pid, Exit: exit}
 		}
 	}
 }


### PR DESCRIPTION
Both BSD's kqueue and Linux's proc connector support exit codes, so
there is no real reason to not provide them to users of the psnotify
library.

Ref: opencontainers/runc#976
Signed-off-by: Aleksa Sarai <asarai@suse.de>