### PR TITLE
ignore the fields not correct in /etc/mtab

### DIFF
--- a/sigar_linux.go
+++ b/sigar_linux.go
@@ -257,6 +257,10 @@ func (self *FileSystemList) Get() error {
 
 	err := readFile("/etc/mtab", func(line string) bool {
 		fields := strings.Fields(line)
+		// Ignore the fields not correct
+		if len(fields) <= 3 {
+			return true
+		}
 
 		fs := FileSystem{}
 		fs.DevName = fields[0]


### PR DESCRIPTION
There maybe empty lines in /etc/mtab, should ignore the lines which is empty, or will crash in :

fs.Options = fields[3]