### PR TITLE
fix memory limit with croup

### DIFF
--- a/sigar_linux.go
+++ b/sigar_linux.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	MaxUint64 = ^uint64(0)
-	// UnlimitedMemorySize defines the bytes size when memory limit is not set
+	// UnlimitedMemorySize defines the bytes size when memory limit is not set (2 ^ 63 - 4096)
 	UnlimitedMemorySize = "9223372036854771712"
 )
 

--- a/sigar_linux.go
+++ b/sigar_linux.go
@@ -499,8 +499,11 @@ func determineMemoryLimit(cgroup string) (uint64, error) {
 		}
 		return true
 	})
+	if err != nil {
+		return 0, err
+	}
 
-	return strtoull(string(limitAsString)), err
+	return strtoull(string(limitAsString))
 }
 
 func determineSelfCgroup(cgroup *string) error {

--- a/sigar_linux_test.go
+++ b/sigar_linux_test.go
@@ -295,7 +295,7 @@ memory2 /smart/fox/jumped/by/lazy/dog/duplicate cgroup2 irrelevant,options
 				memStatSetup(``, ``)
 				limit, err := determineMemoryLimit(``)
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(Equal(`strconv.ParseUint: parsing "": invalid syntax`))
+				Expect(err.Error()).To(Equal(`no hierarchical memory limit found`))
 				Expect(limit).To(BeNumerically("==", 0))
 			})
 			It("fails for missing data in v1 file", func() {

--- a/sigar_linux_test.go
+++ b/sigar_linux_test.go
@@ -287,7 +287,15 @@ memory2 /smart/fox/jumped/by/lazy/dog/duplicate cgroup2 irrelevant,options
 			It("fails for missing files", func() {
 				limit, err := determineMemoryLimit(``)
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(Equal("open " + procd + "/memory/memory.limit_in_bytes: no such file or directory"))
+				// it will falls back to memory.stat when memory.limit_in_bytes not found
+				Expect(err.Error()).To(Equal("open " + procd + "/memory/memory.stat: no such file or directory"))
+				Expect(limit).To(BeNumerically("==", 0))
+			})
+			It("fails for missing data in memory.stat file", func() {
+				memStatSetup(``, ``)
+				limit, err := determineMemoryLimit(``)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal(`strconv.ParseUint: parsing "": invalid syntax`))
 				Expect(limit).To(BeNumerically("==", 0))
 			})
 			It("fails for missing data in v1 file", func() {
@@ -330,6 +338,12 @@ memory2 /smart/fox/jumped/by/lazy/dog/duplicate cgroup2 irrelevant,options
 				limit, err := determineMemoryLimit(``)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(limit).To(BeNumerically("==", 1111))
+			})
+			It("returns hierarchyMemoryLimit when limit_in_bytes is unlimited", func() {
+				memStatSetup(``, `hierarchical_memory_limit 3333`)
+				limit, err := determineMemoryLimit(``)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(limit).To(BeNumerically("==", 3333))
 			})
 			It("signals v2 no limit with failure", func() {
 				memLimitSetup2(``, `max`)


### PR DESCRIPTION
use hierarchical_memory_limit of memory.stat instead of memory.limit_in_bytes since limit_in_bytes is often inherited from pod node and sometimes it's unlimited.  hierarchical_memory_limit is more accurate.
![cgroup_memory_limit](https://user-images.githubusercontent.com/3916488/155867706-3c3eb89a-bb8e-494a-98c1-4220a3d53777.png)

