### PR TITLE
Update README and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ in pure go/cgo, rather than cgo bindings for libsigar.
 
 ## Supported platforms
 
-Currently targeting modern flavors of macOS (Darwin) and Linux.
+Currently targeting modern flavors of macOS (Darwin), Windows and Linux.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ in pure go/cgo, rather than cgo bindings for libsigar.
 
 ## Supported platforms
 
-Currently targeting modern flavors of macOS (darwin) and Linux.
+Currently targeting modern flavors of macOS (Darwin) and Linux.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -9,13 +9,16 @@ in pure go/cgo, rather than cgo bindings for libsigar.
 
 ## Test drive
 
-    $ go get github.com/cloudfoundry/gosigar
-    $ cd $GOPATH/src/github.com/cloudfoundry/gosigar/examples
+    $ git clone https://github.com/cloudfoundry/gosigar.git
+    $ cd gosigar/examples
     $ go run uptime.go
+    $ go run df.go
+    $ go run free.go
+    $ go run ps.go
 
 ## Supported platforms
 
-Currently targeting modern flavors of darwin and linux.
+Currently targeting modern flavors of macOS (darwin) and Linux.
 
 ## License
 

--- a/examples/df.go
+++ b/examples/df.go
@@ -1,9 +1,9 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"os"
-	"strings"
 
 	sigar "github.com/cloudfoundry/gosigar"
 )
@@ -15,24 +15,23 @@ func formatSize(size uint64) string {
 }
 
 func main() {
+	var fileSystemFilter string
+	flag.StringVar(&fileSystemFilter, "t", "", "Filesystem to filter on")
+	flag.Parse()
 	fslist := sigar.FileSystemList{}
 	fslist.Get()
 
 	fmt.Fprintf(os.Stdout, output_format,
 		"Filesystem", "Size", "Used", "Avail", "Use%", "Mounted on")
 
-FSLIST:
 	for _, fs := range fslist.List {
 		dir_name := fs.DirName
 		usage := sigar.FileSystemUsage{}
 		usage.Get(dir_name)
 
-		if strings.HasPrefix(fs.SysTypeName, "fuse") {
-			continue
-		}
-		for _, hiddenPrefix := range []string{"/sys", "/proc", "/run"} {
-			if strings.HasPrefix(dir_name, hiddenPrefix) {
-				continue FSLIST
+		if fileSystemFilter != "" {
+			if fs.SysTypeName != fileSystemFilter {
+				continue
 			}
 		}
 

--- a/examples/df.go
+++ b/examples/df.go
@@ -1,10 +1,11 @@
-package examples
+package main
 
 import (
 	"fmt"
 	"os"
+	"strings"
 
-	"github.com/cloudfoundry/gosigar"
+	sigar "github.com/cloudfoundry/gosigar"
 )
 
 const output_format = "%-15s %4s %4s %5s %4s %-15s\n"
@@ -13,19 +14,27 @@ func formatSize(size uint64) string {
 	return sigar.FormatSize(size * 1024)
 }
 
-func df() {
+func main() {
 	fslist := sigar.FileSystemList{}
 	fslist.Get()
 
 	fmt.Fprintf(os.Stdout, output_format,
 		"Filesystem", "Size", "Used", "Avail", "Use%", "Mounted on")
 
+FSLIST:
 	for _, fs := range fslist.List {
 		dir_name := fs.DirName
-
 		usage := sigar.FileSystemUsage{}
-
 		usage.Get(dir_name)
+
+		if strings.HasPrefix(fs.SysTypeName, "fuse") {
+			continue
+		}
+		for _, hiddenPrefix := range []string{"/sys", "/proc", "/run"} {
+			if strings.HasPrefix(dir_name, hiddenPrefix) {
+				continue FSLIST
+			}
+		}
 
 		fmt.Fprintf(os.Stdout, output_format,
 			fs.DevName,

--- a/examples/free.go
+++ b/examples/free.go
@@ -1,17 +1,17 @@
-package examples
+package main
 
 import (
 	"fmt"
 	"os"
 
-	"github.com/cloudfoundry/gosigar"
+	sigar "github.com/cloudfoundry/gosigar"
 )
 
 func format(val uint64) uint64 {
 	return val / 1024
 }
 
-func free() {
+func main() {
 	mem := sigar.Mem{}
 	swap := sigar.Swap{}
 

--- a/examples/ps.go
+++ b/examples/ps.go
@@ -11,7 +11,7 @@ func main() {
 	pids.Get()
 
 	// ps -eo pid,ppid,stime,time,rss,state,comm
-	fmt.Print("   PID   PPID STIME     TIME    RSS S COMMAND\n")
+	fmt.Print("    PID    PPID STIME     TIME   RSS S COMMAND\n")
 
 	for _, pid := range pids.List {
 		state := sigar.ProcState{}
@@ -28,7 +28,7 @@ func main() {
 			continue
 		}
 
-		fmt.Printf("%6d %6d %s %s %6d %c %s\n",
+		fmt.Printf("%7d %7d %s %s %5d %c %s\n",
 			pid, state.Ppid,
 			time.FormatStartTime(), time.FormatTotal(),
 			mem.Resident/1024, state.State, state.Name)

--- a/examples/ps.go
+++ b/examples/ps.go
@@ -1,17 +1,17 @@
-package examples
+package main
 
 import (
 	"fmt"
 
-	"github.com/cloudfoundry/gosigar"
+	sigar "github.com/cloudfoundry/gosigar"
 )
 
-func ps() {
+func main() {
 	pids := sigar.ProcList{}
 	pids.Get()
 
 	// ps -eo pid,ppid,stime,time,rss,state,comm
-	fmt.Print("  PID  PPID STIME     TIME    RSS S COMMAND\n")
+	fmt.Print("   PID   PPID STIME     TIME    RSS S COMMAND\n")
 
 	for _, pid := range pids.List {
 		state := sigar.ProcState{}
@@ -28,7 +28,7 @@ func ps() {
 			continue
 		}
 
-		fmt.Printf("%5d %5d %s %s %6d %c %s\n",
+		fmt.Printf("%6d %6d %s %s %6d %c %s\n",
 			pid, state.Ppid,
 			time.FormatStartTime(), time.FormatTotal(),
 			mem.Resident/1024, state.State, state.Name)

--- a/examples/uptime.go
+++ b/examples/uptime.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/cloudfoundry/gosigar"
+	sigar "github.com/cloudfoundry/gosigar"
 )
 
 func main() {

--- a/examples/uptime.go
+++ b/examples/uptime.go
@@ -1,4 +1,4 @@
-package examples
+package main
 
 import (
 	"fmt"
@@ -8,14 +8,14 @@ import (
 	"github.com/cloudfoundry/gosigar"
 )
 
-func uptime() {
+func main() {
 	concreteSigar := sigar.ConcreteSigar{}
 
 	uptime := sigar.Uptime{}
 	uptime.Get()
 	avg, err := concreteSigar.GetLoadAverage()
 	if err != nil {
-		fmt.Printf("Failed to get load average")
+		fmt.Printf("Failed to get load average\n")
 		return
 	}
 


### PR DESCRIPTION
Closes #62 

- Use `git clone` instead of `go get` as that no longer works outside of modules.
- Have `main()` as entrypoint for each example and set the package to `main` to allow these to run as stated in the `README.md`
- For `examples/df.go` ignore some noisy things like FUSE etc.