### PR TITLE
Specify Go 1.21.0 version in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudfoundry/gosigar
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/onsi/ginkgo/v2 v2.13.0


### PR DESCRIPTION
Addresses this issue with Dependabot and the Go toolchain: https://github.com/golang/go/issues/62278