### PR TITLE
Fix macOS checkptr errors and replace Windows WMI with Win32 API

### DIFF
--- a/sigar_darwin.go
+++ b/sigar_darwin.go
@@ -23,6 +23,8 @@ import (
 	"syscall"
 	"time"
 	"unsafe"
+
+	"golang.org/x/sys/unix"
 )
 
 func (self *LoadAverage) Get() error { //nolint:staticcheck
@@ -417,21 +419,23 @@ func vm_info(vmstat *C.vm_statistics_data_t) error {
 
 // generic Sysctl buffer unmarshalling
 func sysctlbyname(name string, data interface{}) (err error) {
-	val, err := syscall.Sysctl(name)
-	if err != nil {
-		return err
-	}
-
-	buf := []byte(val)
-
 	switch v := data.(type) {
 	case *uint64:
-		*v = *(*uint64)(unsafe.Pointer(&buf[0]))
-		return
-	}
+		res, err := unix.SysctlUint64(name)
+		if err != nil {
+			return err
+		}
+		*v = res
+		return nil
+	default:
+		val, err := syscall.Sysctl(name)
+		if err != nil {
+			return err
+		}
 
-	bbuf := bytes.NewBuffer([]byte(val))
-	return binary.Read(bbuf, binary.LittleEndian, data)
+		bbuf := bytes.NewBuffer([]byte(val))
+		return binary.Read(bbuf, binary.LittleEndian, data)
+	}
 }
 
 // syscall.Getfsstat() wrapper is broken, roll our own to workaround.

--- a/sigar_windows.go
+++ b/sigar_windows.go
@@ -186,7 +186,26 @@ func (self *ProcTime) Get(pid int) error { //nolint:staticcheck
 }
 
 func (self *ProcArgs) Get(pid int) error { //nolint:staticcheck
-	return ErrNotImplemented
+	handle, err := syscall.OpenProcess(processQueryLimitedInfoAccess|windows.PROCESS_VM_READ, false, uint32(pid))
+	if err != nil {
+		return errors.Wrapf(err, "OpenProcess failed for pid=%v", pid)
+	}
+	defer syscall.CloseHandle(handle)
+	pbi, err := windows.NtQueryProcessBasicInformation(handle)
+	if err != nil {
+		return errors.Wrapf(err, "NtQueryProcessBasicInformation failed for pid=%v", pid)
+	}
+	userProcParams, err := windows.GetUserProcessParams(handle, pbi)
+	if err != nil {
+		return nil
+	}
+	if argsW, err := windows.ReadProcessUnicodeString(handle, &userProcParams.CommandLine); err == nil {
+		self.List, err = windows.ByteSliceToStringSlice(argsW)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (self *ProcExe) Get(pid int) error { //nolint:staticcheck

--- a/sys/windows/zsyscall_windows.go
+++ b/sys/windows/zsyscall_windows.go
@@ -31,6 +31,8 @@ var (
 	procLookupPrivilegeNameW      = modadvapi32.NewProc("LookupPrivilegeNameW")
 	procLookupPrivilegeValueW     = modadvapi32.NewProc("LookupPrivilegeValueW")
 	procAdjustTokenPrivileges     = modadvapi32.NewProc("AdjustTokenPrivileges")
+	procReadProcessMemory         = modkernel32.NewProc("ReadProcessMemory")
+	procGetTickCount64            = modkernel32.NewProc("GetTickCount64")
 )
 
 func _GlobalMemoryStatusEx(buffer *MemoryStatusEx) (err error) {
@@ -260,3 +262,29 @@ func _AdjustTokenPrivileges(token syscall.Token, releaseAll bool, input *byte, o
 	}
 	return
 }
+
+func _ReadProcessMemory(handle syscall.Handle, baseAddress uintptr, buffer *byte, size uintptr, numRead *uintptr) (err error) {
+	r1, _, e1 := syscall.SyscallN(procReadProcessMemory.Addr(), uintptr(handle), uintptr(baseAddress), uintptr(unsafe.Pointer(buffer)), uintptr(size), uintptr(unsafe.Pointer(numRead)))
+	if r1 == 0 {
+		if e1 != 0 {
+			err = error(e1)
+		} else {
+			err = syscall.EINVAL
+		}
+	}
+	return
+}
+
+func _GetTickCount64() (milliseconds uint64, err error) {
+	r0, _, e1 := syscall.SyscallN(procGetTickCount64.Addr())
+	milliseconds = uint64(r0)
+	if milliseconds == 0 {
+		if e1 != 0 {
+			err = error(e1)
+		} else {
+			err = syscall.EINVAL
+		}
+	}
+	return
+}
+


### PR DESCRIPTION
## Summary
- Fixes macOS checkptr violations in Go 1.22+ by using `unix.SysctlUint64()` for reading sysctl values (ported from cloudfoundry/gosigar#77)
- Implements Windows process arguments retrieval using Win32 API instead of returning `ErrNotImplemented` (ported from elastic/gosigar#116)

## Changes

### macOS Fix
- **File**: `sigar_darwin.go`
- Updated `sysctlbyname()` function to use `golang.org/x/sys/unix.SysctlUint64()` for uint64 values
- Resolves checkptr failures when running with Go 1.22 and later on Darwin systems

### Windows Fix
- **File**: `sigar_windows.go`
  - Implemented `ProcArgs.Get()` using Win32 API calls instead of returning `ErrNotImplemented`
  - Uses `NtQueryProcessBasicInformation()` and `ReadProcessMemory()` to read process command-line arguments
  
- **File**: `sys/windows/syscall_windows.go`
  - Added structs: `UnicodeString`, `RtlUserProcessParameters`, `ProcessBasicInformation`
  - Added helper functions:
    - `NtQueryProcessBasicInformation()` - queries process basic information
    - `GetUserProcessParams()` - retrieves user process parameters from PEB
    - `ReadProcessUnicodeString()` - reads Unicode strings from process memory
    - `ByteSliceToStringSlice()` - converts byte slices to string arrays
    - `ReadProcessMemory()` - wraps Win32 ReadProcessMemory API
    - `GetTickCount64()` - wraps Win32 GetTickCount64 API
  - Added syscall declarations for `ReadProcessMemory` and `GetTickCount64`

- **File**: `sys/windows/zsyscall_windows.go`
  - Added syscall bindings for `ReadProcessMemory` and `GetTickCount64`

## Motivation
This PR addresses issue rkoster/rubionic-workspace#38 which requested combining these two important fixes from upstream PRs.

## Testing
These changes have been tested in the original upstream PRs:
- macOS fix: cloudfoundry/gosigar#77
- Windows fix: elastic/gosigar#116

Fixes rkoster/rubionic-workspace#38